### PR TITLE
Fix: Resolve AccessDeniedException on SSE reconnection after timeout

### DIFF
--- a/backend/src/main/java/com/example/notification/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/example/notification/security/JwtAuthenticationFilter.java
@@ -28,14 +28,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-        
         try {
-            String jwt = getJwtFromRequest(request); // Attempts to get from "Authorization" header
+            String jwt = getJwtFromRequest(request); // Only gets from "Authorization" header now
 
-            if (!StringUtils.hasText(jwt) && "/api/notifications/events".equals(request.getServletPath())) {
-                jwt = getJwtFromQueryParam(request);
-            }
-            
             if (StringUtils.hasText(jwt) && jwtTokenProvider.validateToken(jwt)) {
                 String userId = jwtTokenProvider.getUserIdFromJWT(jwt);
                 List<String> roles = jwtTokenProvider.getRolesFromJWT(jwt);
@@ -47,13 +42,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 UsernamePasswordAuthenticationToken authentication = 
                         new UsernamePasswordAuthenticationToken(userId, null, authorities);
                 
-                log.info("JwtAuthenticationFilter: Authenticated user: {} with roles: {}", userId, roles);
+                // General log statement (if you want to keep one for this filter)
+                log.debug("JwtAuthenticationFilter: Authenticated user: {} with roles: {} from Authorization header.", userId, roles);
                 
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }
         } catch (Exception ex) {
-            // Use logger from OncePerRequestFilter or autowire one
-            logger.error("Could not set user authentication in security context", ex);
+            log.error("JwtAuthenticationFilter: Could not set user authentication in security context", ex);
         }
         
         filterChain.doFilter(request, response);

--- a/backend/src/main/java/com/example/notification/security/SseTokenAuthenticationFilter.java
+++ b/backend/src/main/java/com/example/notification/security/SseTokenAuthenticationFilter.java
@@ -1,0 +1,67 @@
+package com.example.notification.security;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@Slf4j
+public class SseTokenAuthenticationFilter implements Filter {
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain)
+            throws IOException, ServletException {
+        HttpServletRequest request = (HttpServletRequest) req;
+        String requestPath = request.getServletPath();
+
+        if ("/api/notifications/events".equals(requestPath)) {
+            log.debug("SSE_AUTH_FILTER: Processing request for path: {}", requestPath);
+            String jwt = request.getParameter("token");
+
+            if (StringUtils.hasText(jwt)) {
+                log.debug("SSE_AUTH_FILTER: Token found in query param for {}. Validating token: {}", requestPath, jwt);
+                boolean isValidToken = jwtTokenProvider.validateToken(jwt);
+                log.debug("SSE_AUTH_FILTER: Token validation result for {}: {}", requestPath, isValidToken);
+
+                if (isValidToken) {
+                    String userId = jwtTokenProvider.getUserIdFromJWT(jwt);
+                    List<String> roles = jwtTokenProvider.getRolesFromJWT(jwt);
+
+                    List<SimpleGrantedAuthority> authorities = roles.stream()
+                            .map(role -> new SimpleGrantedAuthority(role.startsWith("ROLE_") ? role : "ROLE_" + role))
+                            .collect(Collectors.toList());
+
+                    UsernamePasswordAuthenticationToken authentication =
+                            new UsernamePasswordAuthenticationToken(userId, null, authorities);
+
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                    log.debug("SSE_AUTH_FILTER: Authentication successfully set in SecurityContext for user: {}, roles: {}.", userId, roles);
+                } else {
+                    log.warn("SSE_AUTH_FILTER: Invalid JWT token received for path {}. Token: {}", requestPath, jwt);
+                    // If token is invalid, we don't set auth, AnonymousAuth will kick in later if not handled otherwise.
+                }
+            } else {
+                log.debug("SSE_AUTH_FILTER: No JWT token found in query param for path {}.", requestPath);
+            }
+        }
+
+        chain.doFilter(req, res);
+    }
+}


### PR DESCRIPTION
I've addressed an issue where your SSE client reconnections after a server-side timeout would fail with an AccessDeniedException. This was happening because the authentication process wasn't correctly handling the token on the reused thread immediately after the previous SSE request completed.

Here's how I've fixed it:
1.  I introduced `SseTokenAuthenticationFilter`:
    - This is a new `jakarta.servlet.Filter` specifically for handling authentication for `/api/notifications/events` requests.
    - It extracts the JWT from the "token" query parameter and sets up the SecurityContext.
    - This method helps avoid potential issues with `OncePerRequestFilter` on rapidly reused async threads.
2.  I updated `SecurityConfig.java`:
    - I registered `SseTokenAuthenticationFilter` to run before `JwtAuthenticationFilter` and other standard Spring Security filters.
    - I corrected the filter ordering to ensure custom filters run in the proper sequence.
3.  I refactored `JwtAuthenticationFilter.java`:
    - I removed the logic for handling tokens from query parameters for the `/api/notifications/events` path, as `SseTokenAuthenticationFilter` now takes care of this. `JwtAuthenticationFilter` now focuses only on tokens from the "Authorization" header.
4.  I adjusted `SseController.java`:
    - I modified the `onTimeout` handler for `SseEmitter` to call `emitter.complete()` instead of `emitter.completeWithError()`. This change prevents an initial "response already committed" error that was making debugging difficult and possibly leading to instability.
5.  I made some logging adjustments:
    - I added detailed debug logging to `SseTokenAuthenticationFilter` for its operations.
    - I cleaned up diagnostic logging in `JwtAuthenticationFilter`, setting its successful authentication logs to debug.

These changes ensure that SSE reconnections are properly authenticated, preventing the AccessDeniedException and allowing your real-time notifications to resume seamlessly after a timeout.