### PR TITLE
Fix: Address potential causes of duplicate broadcast email notifications

### DIFF
--- a/backend/src/main/java/com/example/notification/controller/SseController.java
+++ b/backend/src/main/java/com/example/notification/controller/SseController.java
@@ -39,9 +39,13 @@ public class SseController {
             logger.warn("Could not extract userId from token for SSE connection.");
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
+        final String userKey = userId; // Effectively final for lambdas
+
+        // Close any existing emitters for this user before creating a new one
+        sseEmitterManager.closeAndRemoveEmittersForUser(userKey);
+
         // Set a timeout
         SseEmitter emitter = new SseEmitter(TimeUnit.MINUTES.toMillis(1));
-        final String userKey = userId; // Effectively final for lambdas
 
         emitter.onCompletion(() -> {
             logger.info("SseEmitter completed for user: {}", userKey);

--- a/backend/src/main/java/com/example/notification/kafka/BroadcastNotificationConsumer.java
+++ b/backend/src/main/java/com/example/notification/kafka/BroadcastNotificationConsumer.java
@@ -22,11 +22,14 @@ public class BroadcastNotificationConsumer {
 
     @KafkaListener(topics = "${notification.kafka.topics.broadcast-notifications}", groupId = "${spring.kafka.consumer.group-id}")
     public void consume(NotificationEvent event) {
-        log.info("Received broadcast notification event from topic {}: {}", broadcastNotificationsTopic, event);
+        // Existing log:
+        log.info("Received broadcast notification event from topic {}: Full Event: {}", broadcastNotificationsTopic, event); // Ensure full event is logged
         try {
-            orchestrator.processBroadcastNotification(event); // Updated
+            log.debug("Calling orchestrator.processBroadcastNotification for eventId: {}", event.getEventId());
+            orchestrator.processBroadcastNotification(event);
+            log.info("Successfully processed broadcast notification eventId: {} via orchestrator.", event.getEventId());
         } catch (Exception e) {
-            log.error("Error processing broadcast notification event: {}", e.getMessage(), e);
+            log.error("Error after orchestrator.processBroadcastNotification for eventId: {}. Error: {}", event.getEventId(), e.getMessage(), e);
             // DLQ logic
         }
     }

--- a/backend/src/main/java/com/example/notification/model/Notification.java
+++ b/backend/src/main/java/com/example/notification/model/Notification.java
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "notifications")
+@Table(name = "notifications", uniqueConstraints = @UniqueConstraint(columnNames = {"eventId", "userId"}))
 public class Notification {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/example/notification/service/NotificationBroadcastService.java
+++ b/backend/src/main/java/com/example/notification/service/NotificationBroadcastService.java
@@ -21,40 +21,43 @@ public class NotificationBroadcastService {
     private final NotificationPersistenceService persistenceService;
     private final NotificationDispatchService dispatchService;
 
-    @Transactional // This method involves multiple database operations and dispatches
+    @Transactional
     public void processBroadcast(NotificationEvent event) {
-        log.info("Processing broadcast notification event: {}", event);
+        log.info("PROCESS_BROADCAST_START: eventId={}, title='{}'", event.getEventId(), event.getTitle()); // New log
 
         List<User> users = userRepository.findAll();
         if (users.isEmpty()) {
-            log.info("No users found to broadcast notification to.");
+            log.info("No users found to broadcast notification to. EventId: {}", event.getEventId());
             return;
         }
-        log.info("Found {} users for broadcast.", users.size());
+        log.info("Found {} users for broadcast. EventId: {}", users.size(), event.getEventId()); // Existing log, ensure eventId
 
+        log.info("PROCESS_BROADCAST_PERSIST: Attempting to persist notifications for eventId={}, userCount={}", event.getEventId(), users.size()); // New log
         List<Notification> savedNotifications = persistenceService.persistBroadcastNotifications(event, users);
-        log.info("{} broadcast notifications successfully saved to the database.", savedNotifications.size());
+        log.info("{} broadcast notifications successfully saved to the database. EventId: {}", savedNotifications.size(), event.getEventId()); // Existing log, ensure eventId
 
         int sseMessagesSent = 0;
         for (Notification savedNotification : savedNotifications) {
             try {
                 NotificationResponse response = persistenceService.convertToResponse(savedNotification);
                 String targetUserId = savedNotification.getUserId();
+
                 dispatchService.dispatchNotification(targetUserId, response);
                 sseMessagesSent++;
+
                 if (event.getPriority() == com.example.notification.model.NotificationPriority.CRITICAL) {
-                    log.info("Dispatching email for CRITICAL priority broadcast to user {} for notification ID {}. Event: {}", targetUserId, response.getId(), event);
+                    log.info("PROCESS_BROADCAST_EMAIL_DISPATCH: Attempting email dispatch for eventId={}, userId={}, notificationId={}", event.getEventId(), targetUserId, response.getId()); // New log
                     dispatchService.dispatchToEmail(targetUserId, response);
                 }
             } catch (Exception e) {
-                log.error("Error converting or dispatching broadcast notification (DB ID: {}) to user {}: {}",
-                          savedNotification.getId(), savedNotification.getUserId(), e.getMessage(), e);
+                log.error("Error in broadcast processing loop for eventId={}, userId={}: {}",
+                          event.getEventId(), savedNotification.getUserId(), e.getMessage(), e); // Enhanced existing error log
             }
         }
         if (event.getPriority() == com.example.notification.model.NotificationPriority.CRITICAL) {
-            log.info("CRITICAL priority broadcast: Attempted to dispatch emails to {} users.", users.size());
+            log.info("CRITICAL priority broadcast: Attempted to dispatch emails to {} users. EventId: {}", users.size(), event.getEventId());
         }
-        log.info("Broadcast notification processing complete. {} notifications created. {} sent via SSE.",
-                  savedNotifications.size(), sseMessagesSent);
+        log.info("PROCESS_BROADCAST_END: eventId={}. {} notifications created. {} sent via SSE.",
+                 event.getEventId(), savedNotifications.size(), sseMessagesSent); // Enhanced existing log
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -44,6 +44,14 @@ spring:
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+    listener:
+      ack-mode: RECORD
+      common-error-handler:
+        enabled: true
+        max-attempts: 3 # Total attempts
+        back-off: 1000  # Backoff interval in ms
+        # For actual DLT, a DeadLetterPublishingRecoverer bean is usually configured.
+        # These properties will use the default DefaultErrorHandler with specified retries/backoff.
   
   # Email Configuration
   mail:


### PR DESCRIPTION
This commit implements several changes to prevent and help diagnose the issue of you receiving multiple emails for a single broadcast notification.

Key changes:
1.  Added a unique constraint `(eventId, userId)` to the `Notification` entity to prevent duplicate notification records in the database for the same event and user.
2.  Enhanced logging in `BroadcastNotificationConsumer` and `NotificationBroadcastService` to include eventIds and improve traceability of broadcast processing.
3.  Updated Kafka consumer configuration in `application.yml`:
    - Set `ack-mode` to `RECORD` for more granular message acknowledgment.
    - Configured the `common-error-handler` with 3 max attempts and a 1000ms backoff to improve resilience against transient errors.
4.  Modified `SseController` to close existing SseEmitters for a user before creating a new one, preventing accumulation of emitters.

These changes aim to make the notification system more robust, improve idempotency in event processing, and provide better diagnostic information if issues persist.